### PR TITLE
support nvme cli

### DIFF
--- a/ezfio.py
+++ b/ezfio.py
@@ -258,6 +258,18 @@ def CollectDriveInfo():
     model = "UNKNOWN"
     serial = "UNKNOWN"
     try:
+        nvmecli = ['nvme', 'list', physDrive]
+        code, info, err = Run(nvmecli)
+        lines = info.split("\n")
+        if len(lines) == 4:
+            data = lines[2].split("  ")
+            model=data[5].lstrip().rstrip()
+            serial=data[2].lstrip().rstrip()
+        else:
+            print "Unable to identify drive using nvmecli. Continuing."
+    except:
+        print "Install nvme-cli to allow model/serial extraction. Continuing."
+    try:
         sdparmcmd = ['sdparm', '--page', 'sn', '--inquiry', '--long',
                      physDrive]
         code, sdparm, err = Run(sdparmcmd)


### PR DESCRIPTION
after apply this patch:

root@nvmeof:~/src/ezfio# ./ezfio.py -d /dev/nvme0n1 -u 10 --yes 
Unable to identify drive using sdparm. Continuing.
***************************************************************************************************
ezFio test parameters:

               Drive: /dev/nvme0n1
               Model: SAMSUNG MZPLL1T6HEHP-00003
              Serial: S3HBNA0K303021
       AvailCapacity: 26 GiB
      TestedCapacity: 2 GiB
                 CPU: Intel Core i3-7100 CPU @ 3.90GHz
               Cores: 4
           Frequency: 3900
         FIO Version: fio-3.8
