### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/ezfio.py
+++ b/ezfio.py
@@ -1163,7 +1163,7 @@ def RunAllTests():
             starttime = datetime.datetime.now()
             job = threading.Thread(target=JobWrapper, kwargs=(o))
             job.start()
-            while job.isAlive():
+            while job.is_alive():
                 now = datetime.datetime.now()
                 delta = now - starttime
                 dstr = "{0:02}:{1:02}:{2:02}".format(int(delta.seconds / 3600),


### PR DESCRIPTION
This is compatible with Python 3 and 2 since is_alive is present in both versions. Fixes #50 